### PR TITLE
Fixed ocroutput request for local mobile tests

### DIFF
--- a/frontend/src/components/ConfirmImage/ConfirmImage.jsx
+++ b/frontend/src/components/ConfirmImage/ConfirmImage.jsx
@@ -45,7 +45,7 @@ const ComfirmImage = () => {
 
     try {
       // Send the fetch request
-      const response = await fetch("http://localhost:8080/outputocr", {
+      const response = await fetch(`${process.env.REACT_APP_API_URL}/outputocr`, {
         method: "POST",
         body: formData,
       });


### PR DESCRIPTION
Change localhost to .env variable to allow mobile tests of Ocrinput