### PR TITLE
ADD:color syntax

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.21.3",
         "react-scripts": "^5.0.1",
+        "react-syntax-highlighter": "^15.6.1",
         "serve": "^14.2.3",
         "web-vitals": "^2.1.4"
       },
@@ -5022,6 +5023,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -5224,6 +5234,12 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -6890,6 +6906,36 @@
         "node": ">=10"
       }
     },
+    "node_modules/character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/check-types": {
       "version": "11.2.3",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.2.3.tgz",
@@ -7130,6 +7176,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -9288,6 +9344,19 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
@@ -9666,6 +9735,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/forwarded": {
@@ -10069,6 +10146,33 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-parse-selector": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+      "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -10076,6 +10180,21 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/highlightjs-vue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+      "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
+      "license": "CC0-1.0"
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -10587,6 +10706,30 @@
         "node": ">= 10"
       }
     },
+    "node_modules/is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -10723,6 +10866,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -10795,6 +10948,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-map": {
@@ -13925,6 +14088,20 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/lowlight": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^1.0.0",
+        "highlight.js": "~10.7.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -14649,6 +14826,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/parse-json": {
@@ -16182,6 +16377,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -16221,6 +16425,19 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/property-information": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/protobufjs": {
       "version": "7.2.6",
@@ -16670,6 +16887,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-syntax-highlighter": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.6.1.tgz",
+      "integrity": "sha512-OqJ2/vL7lEeV5zTJyG7kmARppUjiB9h9udl4qHQjjgEos66z00Ia0OckwYfRxCSFrW8RJIBnsBwQsHZbVPspqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "highlight.js": "^10.4.1",
+        "highlightjs-vue": "^1.0.0",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.27.0",
+        "refractor": "^3.6.0"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -16743,6 +16977,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/refractor": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
+      "integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
+      "license": "MIT",
+      "dependencies": {
+        "hastscript": "^6.0.0",
+        "parse-entities": "^2.0.0",
+        "prismjs": "~1.27.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/prismjs": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/regenerate": {
@@ -17717,6 +17975,16 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead"
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/spdy": {
       "version": "4.0.2",
@@ -20054,6 +20322,15 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.21.3",
     "react-scripts": "^5.0.1",
+    "react-syntax-highlighter": "^15.6.1",
     "serve": "^14.2.3",
     "web-vitals": "^2.1.4"
   },

--- a/frontend/src/components/Account/Account.css
+++ b/frontend/src/components/Account/Account.css
@@ -40,7 +40,8 @@
   color: #555;
 }
 
-.font-size-selector {
+.font-size-selector,
+.syntax-selector {
   width: 100%;
   padding: 12px;
   border: 2px solid #ddd;
@@ -51,12 +52,14 @@
   transition: border-color 0.3s ease;
 }
 
-.font-size-selector:focus {
+.font-size-selector:focus,
+.syntax-selector:focus {
   outline: none;
   border-color: var(--primary-color, #444AD4);
 }
 
-.font-size-selector:hover {
+.font-size-selector:hover,
+.syntax-selector:hover {
   border-color: #bbb;
 }
 
@@ -80,8 +83,8 @@
   padding: 10px;
   border-radius: 4px;
   border: 1px solid #ddd;
-  color: #333;
   white-space: pre-wrap;
+  transition: all 0.3s ease;
 }
 
 .logout-button {

--- a/frontend/src/components/Account/Account.jsx
+++ b/frontend/src/components/Account/Account.jsx
@@ -8,6 +8,8 @@ import { signOut } from "firebase/auth";
 import { useNavigate } from "react-router-dom";
 import SolidButton from "../buttons/Solid/SolidButton";
 import { FiLogOut } from "react-icons/fi";
+import SimpleSyntaxHighlighter from "../SimpleSyntaxHighlighter/SimpleSyntaxHighlighter";
+
 const Account = () => {
   const { setTriggerUpdateAuthContext, user } = useAuthContext();
   const { settings, updateSetting } = useSettingsContext();
@@ -37,11 +39,23 @@ const Account = () => {
     updateSetting('codeFontSize', event.target.value);
   };
 
+  const handleSyntaxChange = (event) => {
+    updateSetting('syntaxHighlight', event.target.value === 'true');
+  };
+
   const fontSizeOptions = [
     { value: '1rem', label: 'Small' },
     { value: '1.25rem', label: 'Medium' },
     { value: '1.5rem', label: 'Big' }
   ];
+
+  const syntaxOptions = [
+    { value: 'true', label: 'Default (with syntax colors)' },
+    { value: 'false', label: 'No Syntax Color (all black)' }
+  ];
+
+  // Safely get the syntaxHighlight value with fallback
+  const syntaxHighlightValue = settings.syntaxHighlight !== undefined ? settings.syntaxHighlight : true;
 
   return (
     <div className="account-page">
@@ -50,14 +64,14 @@ const Account = () => {
       </div>
       
       <div className="settings-section">
-        <h3>Settings</h3>
+        <h3>Code Settings</h3>
         
         <div className="setting-item">
           <label htmlFor="font-size-selector">Choose Code Font Size:</label>
           <select 
             id="font-size-selector"
             className="font-size-selector"
-            value={settings.codeFontSize} 
+            value={settings.codeFontSize || '1rem'} 
             onChange={handleFontSizeChange}
           >
             {fontSizeOptions.map(option => (
@@ -68,13 +82,31 @@ const Account = () => {
           </select>
         </div>
 
+        <div className="setting-item">
+          <label htmlFor="syntax-selector">Choose Syntax Highlighting:</label>
+          <select 
+            id="syntax-selector"
+            className="syntax-selector"
+            value={syntaxHighlightValue.toString()} 
+            onChange={handleSyntaxChange}
+          >
+            {syntaxOptions.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
         <div className="preview-section">
           <p>Preview:</p>
-          <div 
-            className="code-preview" 
-            style={{ fontSize: settings.codeFontSize }}
-          >
-            {'Hello World!'}
+          <div className="code-preview">
+            <SimpleSyntaxHighlighter 
+              code={'<div>Hello World!</div>'}
+              language="markup"
+              syntaxHighlight={syntaxHighlightValue}
+              style={{ fontSize: settings.codeFontSize || '1rem' }}
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/components/CodeTabContent/CodeTabContent.css
+++ b/frontend/src/components/CodeTabContent/CodeTabContent.css
@@ -22,24 +22,43 @@
 }
 
 .code-line {
-  display: flex;
+  display: grid;
+  grid-template-columns: 60px 1fr;
   align-items: center;
-  padding: 4px;
-  cursor: pointer;
+  gap: 8px;
+  line-height: var(--row-line-height);
+  min-height: calc(var(--row-line-height) + 8px);
+  font-family: inherit;
+  transition: background-color 0.2s ease;
+}
+
+.code-text {
+  display: block;
   overflow: hidden;
+  white-space: pre-wrap;  
+  word-break: break-word;
+  font-family: inherit;
+  line-height: inherit;
+}
+
+.code-text pre,
+.code-text code,
+.code-text span {
+  margin: 0 !important;
+  padding: 0 !important;
+  background: transparent !important;
+  font-family: inherit !important;
+  line-height: inherit !important;
+  white-space: inherit !important;
 }
 
 .line-number {
-  margin-right: 8px;
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  min-width: 60px;
-  height: 30px;
-}
-
-.line-number.has-errors {
   gap: 6px;
+  min-width: 60px;
+  height: auto;
 }
 
 .line-number-text {
@@ -52,14 +71,6 @@
 
 .error-icon {
   flex-shrink: 0;
-}
-
-.code {
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  overflow: hidden;
 }
 
 .even {
@@ -297,12 +308,6 @@ input {
   border: 1px solid #e0e0e0;
 }
 
-.menu-codeline-content {
-  font-family: monospace;
-  display: block;
-  line-height: 1.4;
-}
-
 .menu-popup {
   width: 100%;
   background: #fff;
@@ -390,4 +395,27 @@ input {
   width: 100%;
   height: 100%;
   background-color: #333;
+}
+
+.menu-codeline-content {
+  display: block;
+  font-family: inherit;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.menu-codeline-content pre,
+.menu-codeline-content code,
+.menu-codeline-content span {
+  margin: 0 !important;
+  padding: 0 !important;
+  background: transparent !important;
+  font-family: inherit !important;
+  line-height: inherit !important;
+  white-space: inherit !important;
+}
+
+.menu-codeline-content .token {
+  line-height: inherit !important;
 }

--- a/frontend/src/components/CodeTabContent/CodeTabContent.jsx
+++ b/frontend/src/components/CodeTabContent/CodeTabContent.jsx
@@ -1,6 +1,5 @@
 import { useRef } from "react";
 import "./CodeTabContent.css";
-import redErrorIcon from "../../assets/red-error.png";
 import { useCodeTabLogic } from "../../hooks/useCodeTabLogic";
 import { useSettingsContext } from "../../contexts/settingsContext";
 import { MdDelete } from "react-icons/md";
@@ -8,6 +7,7 @@ import { FaPlus } from "react-icons/fa";
 import { BiSolidPencil } from "react-icons/bi";
 import { MdError } from "react-icons/md";
 import SolidButton from "../buttons/Solid/SolidButton";
+import SimpleSyntaxHighlighter from "../SimpleSyntaxHighlighter/SimpleSyntaxHighlighter";
 
 const CodeTabContent = ({ codeProcessor }) => {
   const {
@@ -41,6 +41,22 @@ const CodeTabContent = ({ codeProcessor }) => {
     handleEditLine,
     handleOverlayClick
   } = useCodeTabLogic(codeProcessor);
+
+  // Language detection for syntax highlighting (no longer used for highlighting, but kept for consistency)
+  const getLanguageForLine = (lineContent) => {
+    if (lineContent.includes('<script>') || lineContent.includes('</script>')) {
+      return 'javascript';
+    }
+    if (lineContent.includes('<style>') || lineContent.includes('</style>')) {
+      return 'css';
+    }
+    return 'markup';
+  };
+
+  // Get syntax highlighting setting
+  const getSyntaxHighlight = () => {
+    return settings.syntaxHighlight !== undefined ? settings.syntaxHighlight : true;
+  };
 
   if (isLoading) {
     return <div>Loading</div>;
@@ -80,7 +96,14 @@ const CodeTabContent = ({ codeProcessor }) => {
                 <MdError color={"#EB5031"} size={20} className="error-icon" alt="Error"/>
               )}
             </span>
-            <span className="code">{line[0]}</span>
+          <span className="code code-text">
+            <SimpleSyntaxHighlighter 
+              code={line[0]}
+              language={getLanguageForLine(line[0])}
+              syntaxHighlight={getSyntaxHighlight()}
+              style={{ fontSize: settings.codeFontSize }}
+            />
+          </span>
           </div>
         ))}
       </div>
@@ -117,7 +140,12 @@ const CodeTabContent = ({ codeProcessor }) => {
                   <div className="popup-line-info">
                     <span className="popup-line-label">Line {selectedLineIndex + 1}:</span>
                     <div className="popup-line-content" style={{ fontFamily: 'monospace', fontSize: settings.codeFontSize }}>
-                      {processedHTML[selectedLineIndex][0]}
+                      <SimpleSyntaxHighlighter 
+                        code={processedHTML[selectedLineIndex][0]}
+                        language={getLanguageForLine(processedHTML[selectedLineIndex][0])}
+                        syntaxHighlight={getSyntaxHighlight()}
+                        style={{ fontSize: settings.codeFontSize }}
+                      />
                     </div>
                   </div>
                 </>
@@ -128,7 +156,12 @@ const CodeTabContent = ({ codeProcessor }) => {
                   <div className="popup-line-info">
                     <span className="popup-line-label">Line {selectedLineIndex + 1}:</span>
                     <div className="popup-line-content" style={{ fontFamily: 'monospace', fontSize: settings.codeFontSize }}>
-                      {processedHTML[selectedLineIndex][0]}
+                      <SimpleSyntaxHighlighter 
+                        code={processedHTML[selectedLineIndex][0]}
+                        language={getLanguageForLine(processedHTML[selectedLineIndex][0])}
+                        syntaxHighlight={getSyntaxHighlight()}
+                        style={{ fontSize: settings.codeFontSize }}
+                      />
                     </div>
                   </div>
                   <span className="popup-line-label">New line:</span>
@@ -159,7 +192,12 @@ const CodeTabContent = ({ codeProcessor }) => {
               {purposeOfPopUp === "Deleting" && (
                 <div className="popup-line-info">
                   <div className="popup-line-content" style={{ fontFamily: 'monospace', fontSize: settings.codeFontSize }}>
-                    {processedHTML[selectedLineIndex][0]}
+                    <SimpleSyntaxHighlighter 
+                      code={processedHTML[selectedLineIndex][0]}
+                      language={getLanguageForLine(processedHTML[selectedLineIndex][0])}
+                      syntaxHighlight={getSyntaxHighlight()}
+                      style={{ fontSize: settings.codeFontSize }}
+                    />
                   </div>
                 </div>
               )}
@@ -205,33 +243,41 @@ const CodeTabContent = ({ codeProcessor }) => {
 
               <div className="menu-codeline" style={{ fontSize: settings.codeFontSize }}>
                 <span className="menu-codeline-content">
-                  {processedHTML[selectedLineIndex][0]}
+                  <SimpleSyntaxHighlighter 
+                    code={processedHTML[selectedLineIndex][0]}
+                    language={getLanguageForLine(processedHTML[selectedLineIndex][0])}
+                    syntaxHighlight={getSyntaxHighlight()}
+                    style={{ fontSize: settings.codeFontSize }}
+                  />
                 </span>
               </div>
 
-              <div className="menu-row" >
-             <SolidButton onClick={handleEditLine}><BiSolidPencil size={20} style={{ marginRight: "5px"}} />
-              Edit Line
-             </SolidButton>
+              <div className="menu-row">
+                <SolidButton onClick={handleEditLine}>
+                  <BiSolidPencil size={20} style={{ marginRight: "5px"}} />
+                  Edit Line
+                </SolidButton>
               </div>
               <div className="menu-grey-line"></div>
               <div className="menu-row">
-             <SolidButton onClick={handleAddLineBefore}><FaPlus size={20} style={{ marginRight: "5px"}} />
-              Add Line Before
-             </SolidButton>
+                <SolidButton onClick={handleAddLineBefore}>
+                  <FaPlus size={20} style={{ marginRight: "5px"}} />
+                  Add Line Before
+                </SolidButton>
               </div>
               <div className="menu-grey-line"></div>
               <div className="menu-row">
-              <SolidButton onClick={handleAddLineAfter}><FaPlus size={20} style={{ marginRight: "5px"}} />
-              Add Line After
-             </SolidButton>
+                <SolidButton onClick={handleAddLineAfter}>
+                  <FaPlus size={20} style={{ marginRight: "5px"}} />
+                  Add Line After
+                </SolidButton>
               </div>
               <div className="menu-grey-line"></div>
-              
               <div className="menu-row">
-              <SolidButton onClick={handleDeleteLine} color="#E53935"><MdDelete style={{ marginRight: "5px" }} />
-              Delete Line
-             </SolidButton>
+                <SolidButton onClick={handleDeleteLine} color="#E53935">
+                  <MdDelete style={{ marginRight: "5px" }} />
+                  Delete Line
+                </SolidButton>
               </div>
             </div>
           </div>

--- a/frontend/src/components/SimpleSyntaxHighlighter/SimpleSyntaxHighlighter.jsx
+++ b/frontend/src/components/SimpleSyntaxHighlighter/SimpleSyntaxHighlighter.jsx
@@ -1,0 +1,55 @@
+// components/SyntaxHighlighter/SimpleSyntaxHighlighter.jsx
+
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { prism } from 'react-syntax-highlighter/dist/esm/styles/prism';
+
+const SimpleSyntaxHighlighter = ({ 
+  code, 
+  language = 'markup',
+  syntaxHighlight = true,
+  className = '',
+  style = {}
+}) => {
+  
+  // If syntax highlighting is disabled, show plain black text
+  if (!syntaxHighlight) {
+    return (
+      <span
+        className={className}
+        style={{
+          color: '#000000',
+          fontFamily: 'monospace',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          ...style
+        }}
+      >
+        {code || ''}
+      </span>
+    );
+  }
+
+  // If syntax highlighting is enabled, use Prism with default light theme
+  return (
+    <SyntaxHighlighter
+      language={language}
+      style={prism}
+      PreTag="span"
+      CodeTag="span"
+      className={className}
+      customStyle={{
+        background: 'transparent',
+        backgroundColor: 'transparent',
+        margin: 0,
+        padding: 0,
+        border: 'none',
+        borderRadius: 0,
+        ...style
+      }}
+    >
+      {code || ''}
+    </SyntaxHighlighter>
+  );
+};
+
+export default SimpleSyntaxHighlighter;

--- a/frontend/src/contexts/settingsContext.jsx
+++ b/frontend/src/contexts/settingsContext.jsx
@@ -20,6 +20,7 @@ export const SettingsProvider = ({ children }) => {
         const parsedSettings = JSON.parse(savedSettings);
         return {
           codeFontSize: '1rem', // Default font size
+          syntaxHighlight: true, // Default syntax highlighting
           ...parsedSettings // Override with saved settings if they exist
         };
       }
@@ -30,6 +31,7 @@ export const SettingsProvider = ({ children }) => {
     // If no settings are found, return default settings
     return {
       codeFontSize: '1rem',
+      syntaxHighlight: true, // true for syntax highlighting, false for plain black text
     };
   };
 
@@ -50,6 +52,7 @@ export const SettingsProvider = ({ children }) => {
   const resetSettings = () => {
     setSettings({
       codeFontSize: '1rem',
+      syntaxHighlight: true,
     });
     localStorage.removeItem('appSettings');
   };


### PR DESCRIPTION
# Syntax Highlighting Toggle Implementation

## Overview

Replaced the complex theme system with a simple syntax highlighting toggle. Users can now choose between colored syntax highlighting or plain black text. The setting persists in localStorage and applies across the entire editor.

## Core Changes


### Settings Page
Added a clear dropdown with two options:
- "Default (with syntax colors)" 
- "No Syntax Color (all black)"

Includes a live preview that shows `<div>Hello World!</div>` with the actual highlighting component.

